### PR TITLE
Add synopsis check

### DIFF
--- a/InModule.Help.Tests.ps1
+++ b/InModule.Help.Tests.ps1
@@ -151,6 +151,10 @@ foreach ($command in $commands)
 		It "should not be auto-generated" {
 			$Help.Synopsis | Should Not BeLike '*`[`<CommonParameters`>`]*'
 		}
+
+		It "synopsis should not be left out of existing help" {
+			$Help.Synopsis | Should Not beNullOrEmpty
+		}
 		
 		# Should be a description for every function
 		It "gets description for $commandName" {

--- a/Module.Help.Tests.ps1
+++ b/Module.Help.Tests.ps1
@@ -237,6 +237,10 @@ foreach ($command in $commands) {
 		It "should not be auto-generated" {
 			$Help.Synopsis | Should Not BeLike '*`[`<CommonParameters`>`]*'
 		}
+
+		It "synopsis should not be left out of existing help" {
+			$Help.Synopsis | Should Not beNullOrEmpty
+		}
 		
 		# Should be a description for every function
 		It "gets description for $commandName" {


### PR DESCRIPTION
The check whether the SYNOPSIS is auto-generated only works if there is no help. If there is help and the SYNOPSIS tag is left out your test comes back as passed.

I added a second check to make sure that if there is help, that synopsis is not empty.

The two checks should catch all possible unwanted states Synopsis can be in.
