### PR TITLE
Added Module Link URI Tests

### DIFF
--- a/InModule.Help.Tests.ps1
+++ b/InModule.Help.Tests.ps1
@@ -220,7 +220,7 @@ foreach ($command in $commands)
 	}
 
     Describe "$CommandName : URL links should be valid" -Tag Links {
-        $Links = $help.relatedLinks.navigationLink.uri | Where-Object {$_ -ne ''}
+        $Links = $help.relatedLinks.navigationLink.uri | Where-Object { ($_ -ne '') -AND ($_ -ne $Null) }
 
         foreach ($Link in $Links)
         {

--- a/InModule.Help.Tests.ps1
+++ b/InModule.Help.Tests.ps1
@@ -217,5 +217,21 @@ foreach ($command in $commands)
 				}
 			}
 		}
+
+        Context "$CommandName Help Links should be Valid" {            
+            $Links = $help.relatedLinks.navigationLink.uri
+        
+            foreach ($Link in $Links)
+            {
+                If ($Link)
+                {
+                    # Should have a valid uri if one is provided.
+                    It "[$Link] should have 200 Status Code for $CommandName" {        
+                        $Results = Invoke-WebRequest -Uri $Link -UseBasicParsing
+                        $Results.StatusCode | Should Be '200'
+                    }
+                }
+            }
+        }
 	}
 }

--- a/InModule.Help.Tests.ps1
+++ b/InModule.Help.Tests.ps1
@@ -217,21 +217,18 @@ foreach ($command in $commands)
 				}
 			}
 		}
+	}
 
-        Context "$CommandName Help Links should be Valid" {            
-            $Links = $help.relatedLinks.navigationLink.uri
-        
-            foreach ($Link in $Links)
-            {
-                If ($Link)
-                {
-                    # Should have a valid uri if one is provided.
-                    It "[$Link] should have 200 Status Code for $CommandName" {        
-                        $Results = Invoke-WebRequest -Uri $Link -UseBasicParsing
-                        $Results.StatusCode | Should Be '200'
-                    }
-                }
+    Describe "$CommandName : URL links should be valid" -Tag Links {
+        $Links = $help.relatedLinks.navigationLink.uri | Where-Object {$_ -ne ''}
+
+        foreach ($Link in $Links)
+        {
+            # Uri returns OK. Doesn't verify content
+            It "[$Link] has 200 status code" {
+                $Results = Invoke-WebRequest -Uri $Link -UseBasicParsing
+                $Results.StatusCode | Should Be '200'
             }
         }
-	}
+    }
 }

--- a/Module.Help.Tests.ps1
+++ b/Module.Help.Tests.ps1
@@ -301,5 +301,22 @@ foreach ($command in $commands) {
 				}
 			}
 		}
+        
+        
+        Context "$CommandName Help Links should be Valid" {            
+            $Links = $help.relatedLinks.navigationLink.uri
+        
+            foreach ($Link in $Links)
+            {
+                If ($Link)
+                {
+                    # Should have a valid uri if one is provided.
+                    It "[$Link] should have 200 Status Code for $CommandName" {        
+                        $Results = Invoke-WebRequest -Uri $Link -UseBasicParsing
+                        $Results.StatusCode | Should Be '200'
+                    }
+                }
+            }
+        }
 	}
 }

--- a/Module.Help.Tests.ps1
+++ b/Module.Help.Tests.ps1
@@ -301,22 +301,18 @@ foreach ($command in $commands) {
 				}
 			}
 		}
-        
-        
-        Context "$CommandName Help Links should be Valid" {            
-            $Links = $help.relatedLinks.navigationLink.uri
-        
-            foreach ($Link in $Links)
-            {
-                If ($Link)
-                {
-                    # Should have a valid uri if one is provided.
-                    It "[$Link] should have 200 Status Code for $CommandName" {        
-                        $Results = Invoke-WebRequest -Uri $Link -UseBasicParsing
-                        $Results.StatusCode | Should Be '200'
-                    }
-                }
+	}
+
+    Describe "$CommandName : URL links should be valid" -Tag Links {
+        $Links = $help.relatedLinks.navigationLink.uri | Where-Object {$_ -ne ''}
+
+        foreach ($Link in $Links)
+        {
+            # Uri returns OK. Doesn't verify content
+            It "[$Link] has 200 status code" {
+                $Results = Invoke-WebRequest -Uri $Link -UseBasicParsing
+                $Results.StatusCode | Should Be '200'
             }
         }
-	}
+    }
 }

--- a/Module.Help.Tests.ps1
+++ b/Module.Help.Tests.ps1
@@ -304,7 +304,7 @@ foreach ($command in $commands) {
 	}
 
     Describe "$CommandName : URL links should be valid" -Tag Links {
-        $Links = $help.relatedLinks.navigationLink.uri | Where-Object {$_ -ne ''}
+        $Links = $help.relatedLinks.navigationLink.uri | Where-Object { ($_ -ne '') -AND ($_ -ne $Null) }
 
         foreach ($Link in $Links)
         {


### PR DESCRIPTION
- If a uri is provided it will use Invoke-WebRequest and expect a 200 response code.
- I have found 1 link so far that gave a false positive. The site was blocking the request via IWR but allowed via browser.
- I have found this Helpful in what I have worked on, but maybe there could be instances where a URI is known to be non functioning and that is expected. 
- There is also the scenario of Tests being ran offline. So, this may be something that is given as an option.
